### PR TITLE
Add WebSocket server option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -589,6 +595,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +787,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,9 +816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1244,6 +1270,7 @@ dependencies = [
  "ctrlc",
  "kokorox",
  "kokorox-openai",
+ "kokorox-websocket",
  "regex",
  "rodio",
  "sentence_segmentation",
@@ -1277,6 +1304,19 @@ dependencies = [
  "kokorox",
  "serde",
  "tower-http",
+]
+
+[[package]]
+name = "kokorox-websocket"
+version = "0.1.0"
+dependencies = [
+ "base64 0.21.7",
+ "futures-util",
+ "kokorox",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
 ]
 
 [[package]]
@@ -1825,6 +1865,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,6 +1930,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,7 +2009,7 @@ version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2193,6 +2272,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2510,6 +2600,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,6 +2712,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,7 +2766,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "log",
  "once_cell",
  "rustls",
@@ -2665,6 +2786,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["koko", "kokorox", "kokorox-openai"]
+members = ["koko", "kokorox", "kokorox-openai", "kokorox-websocket"]
 resolver = "2"
 
 

--- a/koko/Cargo.toml
+++ b/koko/Cargo.toml
@@ -16,6 +16,7 @@ eula = false
 [dependencies]
 kokorox = { path = "../kokorox" }
 kokorox-openai = { path = "../kokorox-openai" }
+kokorox-websocket = { path = "../kokorox-websocket" }
 
 clap = { version = "4.5.26", features = ["derive"] }
 tokio = { version = "1.0", features = ["io-util", "rt-multi-thread"] }

--- a/kokorox-websocket/Cargo.toml
+++ b/kokorox-websocket/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "kokorox-websocket"
+version = "0.1.0"
+edition = "2021"
+homepage = "https://github.com/WismutHansen/kokorox"
+authors = ["Lucas Jin", "Tommy Falkowski"]
+description = "WebSocket server for Kokorox TTS"
+
+[dependencies]
+kokorox = { path = "../kokorox" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+base64 = "0.21"
+futures-util = "0.3"
+tokio = { version = "1.0", features = ["io-util", "net", "rt", "macros"] }
+tokio-tungstenite = "0.21"

--- a/kokorox-websocket/src/lib.rs
+++ b/kokorox-websocket/src/lib.rs
@@ -1,0 +1,192 @@
+use std::net::SocketAddr;
+
+use futures_util::{SinkExt, StreamExt};
+use kokorox::tts::koko::TTSKoko;
+use serde::{Deserialize, Serialize};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+#[derive(Deserialize)]
+struct ClientCommand {
+    command: String,
+    text: Option<String>,
+    voice: Option<String>,
+}
+
+#[derive(Serialize)]
+struct AudioChunk<'a> {
+    #[serde(rename = "type")]
+    msg_type: &'a str,
+    chunk: &'a str,
+    index: usize,
+    total: usize,
+    sample_rate: u32,
+}
+
+#[derive(Serialize)]
+struct SimpleMsg<'a> {
+    #[serde(rename = "type")]
+    msg_type: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    voice: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    voices: Option<&'a [String]>,
+}
+
+async fn handle_connection(stream: TcpStream, tts: TTSKoko) {
+    if let Ok(ws_stream) = accept_async(stream).await {
+        let voices = tts.get_available_voices();
+        let sample_rate = tts.sample_rate();
+        let mut current_voice = voices
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "af_heart".to_string());
+        let (mut write, mut read) = ws_stream.split();
+
+        while let Some(Ok(msg)) = read.next().await {
+            if let Message::Text(text) = msg {
+                match serde_json::from_str::<ClientCommand>(&text) {
+                    Ok(cmd) => match cmd.command.as_str() {
+                        "list_voices" => {
+                            let reply = SimpleMsg {
+                                msg_type: "voices",
+                                voice: Some(&current_voice),
+                                voices: Some(&voices),
+                            };
+                            if let Ok(json) = serde_json::to_string(&reply) {
+                                let _ = write.send(Message::Text(json)).await;
+                            }
+                        }
+                        "set_voice" => {
+                            if let Some(v) = cmd.voice {
+                                if voices.contains(&v) {
+                                    current_voice = v.clone();
+                                    let reply = SimpleMsg {
+                                        msg_type: "voice_changed",
+                                        voice: Some(&current_voice),
+                                        voices: None,
+                                    };
+                                    if let Ok(json) = serde_json::to_string(&reply) {
+                                        let _ = write.send(Message::Text(json)).await;
+                                    }
+                                } else {
+                                    let reply = SimpleMsg {
+                                        msg_type: "error",
+                                        voice: None,
+                                        voices: None,
+                                    };
+                                    let _ = write
+                                        .send(Message::Text(serde_json::to_string(&reply).unwrap()))
+                                        .await;
+                                }
+                            }
+                        }
+                        "synthesize" => {
+                            if let Some(text) = cmd.text {
+                                let _ = write
+                                    .send(Message::Text(
+                                        serde_json::to_string(&SimpleMsg {
+                                            msg_type: "synthesis_started",
+                                            voice: None,
+                                            voices: None,
+                                        })
+                                        .unwrap(),
+                                    ))
+                                    .await;
+                                match tts.tts_raw_audio(
+                                    &text,
+                                    "en-us",
+                                    &current_voice,
+                                    1.0,
+                                    None,
+                                    false,
+                                    true,
+                                ) {
+                                    Ok(audio) => {
+                                        let encoded = encode_audio(&audio);
+                                        let chunk = AudioChunk {
+                                            msg_type: "audio_chunk",
+                                            chunk: &encoded,
+                                            index: 0,
+                                            total: 1,
+                                            sample_rate,
+                                        };
+                                        if let Ok(json) = serde_json::to_string(&chunk) {
+                                            let _ = write.send(Message::Text(json)).await;
+                                        }
+                                        let done = SimpleMsg {
+                                            msg_type: "synthesis_completed",
+                                            voice: None,
+                                            voices: None,
+                                        };
+                                        let _ = write
+                                            .send(Message::Text(
+                                                serde_json::to_string(&done).unwrap(),
+                                            ))
+                                            .await;
+                                    }
+                                    Err(e) => {
+                                        let err = SimpleMsg {
+                                            msg_type: "error",
+                                            voice: None,
+                                            voices: None,
+                                        };
+                                        let _ = write
+                                            .send(Message::Text(
+                                                serde_json::to_string(&err).unwrap(),
+                                            ))
+                                            .await;
+                                        eprintln!("TTS error: {}", e);
+                                    }
+                                }
+                            }
+                        }
+                        _ => {
+                            let reply = SimpleMsg {
+                                msg_type: "error",
+                                voice: None,
+                                voices: None,
+                            };
+                            let _ = write
+                                .send(Message::Text(serde_json::to_string(&reply).unwrap()))
+                                .await;
+                        }
+                    },
+                    Err(_) => {
+                        let reply = SimpleMsg {
+                            msg_type: "error",
+                            voice: None,
+                            voices: None,
+                        };
+                        let _ = write
+                            .send(Message::Text(serde_json::to_string(&reply).unwrap()))
+                            .await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn encode_audio(samples: &[f32]) -> String {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    let mut bytes = Vec::with_capacity(samples.len() * 2);
+    for &s in samples {
+        let v = (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    STANDARD.encode(bytes)
+}
+
+/// Start the WebSocket server
+pub async fn start_server(tts: TTSKoko, addr: SocketAddr) -> tokio::io::Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    println!("WebSocket server listening on {}", addr);
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let tts_clone = tts.clone();
+        tokio::spawn(async move {
+            handle_connection(stream, tts_clone).await;
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add `kokorox-websocket` crate implementing a simple WebSocket server
- expose new `websocket`/`ws` subcommand in CLI
- wire CLI to start the new WebSocket server
- register new crate in workspace and CLI dependencies

## Testing
- `cargo fmt --manifest-path kokorox-websocket/Cargo.toml`
- `cargo fmt --manifest-path koko/Cargo.toml`
- `cargo check` *(fails: Failed to GET `https://parcel.pyke.io/...`)*

------
https://chatgpt.com/codex/tasks/task_b_686d5a9f1794832181e85120ef4e6462